### PR TITLE
BDA-36: Makes music splitter K8s ready.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,20 @@
 .DS_STORE
 downloads/
 
+# Music Splitter
 music_splitter/temp_input/
 *pretrained_models
 music_splitter/output
 
+# Pycache files
 *.pyc
 *.pyo
 
 *cred*
+
+# Terraform state files (local, contains sensitive info)
+*.tfstate
+*.tfstate.*
+
+# Terraform working directory (providers, plugins, caches)
+.terraform/

--- a/music_splitter/music_splitter.py
+++ b/music_splitter/music_splitter.py
@@ -81,8 +81,14 @@ def callback(ch, method, properties, body):
 
 def start_worker():
     # TODO: Add a health check endpoint implementation.
+    print("Starting music splitter worker...")
+    credentials = pika.PlainCredentials(constants.RABBITMQ_USER, constants.RABBITMQ_PASS)
+    connection = pika.BlockingConnection(pika.ConnectionParameters(
+        host=constants.RABBITMQ_HOST,
+        port=constants.RABBITMQ_PORT,
+        credentials=credentials
+    ))
 
-    connection = pika.BlockingConnection(pika.ConnectionParameters(constants.RABBITMQ_HOST))
     channel = connection.channel()
 
     channel.queue_declare(queue=constants.SPLIT_QUEUE_NAME)

--- a/shared/constants.py
+++ b/shared/constants.py
@@ -2,8 +2,9 @@ import os
 
 # RabbitMQ related constants
 RABBITMQ_HOST = os.getenv('RABBITMQ_HOST', 'localhost')
-RABBITMQ_USER = os.getenv('RABBITMQ_USER', 'guest')
-RABBITMQ_PASSWORD = os.getenv('RABBITMQ_PASSWORD', 'guest')
+RABBITMQ_PORT = 5672
+RABBITMQ_USER = os.getenv('RABBITMQ_USER', 'user')
+RABBITMQ_PASS = os.getenv('RABBITMQ_PASS', 'password')
 
 GCS_BUCKET_NAME = 'bda-media-bucket'
 SPLIT_QUEUE_NAME = "split-jobs"

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "2.12.1"
+  constraints = "~> 2.12.0"
+  hashes = [
+    "h1:7wfYOAeSEchHB8idNl+2jf+OkFi9zFSOLWkEZFuTCik=",
+    "zh:1d623fb1662703f2feb7860e3c795d849c77640eecbc5a776784d08807b15004",
+    "zh:253a5bc62ba2c4314875139e3fbd2feaad5ef6b0fb420302a474ab49e8e51a38",
+    "zh:282358f4ad4f20d0ccaab670b8645228bfad1c03ac0d0df5889f0aea8aeac01a",
+    "zh:4fd06af3091a382b3f0d8f0a60880f59640d2b6d9d6a31f9a873c6f1bde1ec50",
+    "zh:6816976b1830f5629ae279569175e88b497abbbac30ee809948a1f923c67a80d",
+    "zh:7d82c4150cdbf48cfeec867be94c7b9bd7682474d4df0ebb7e24e148f964844f",
+    "zh:83f062049eea2513118a4c6054fb06c8600bac96196f25aed2cc21898ec86e93",
+    "zh:a79eec0cf4c08fca79e44033ec6e470f25ff23c3e2c7f9bc707ed7771c1072c0",
+    "zh:b2b2d904b2821a6e579910320605bc478bbef063579a23fbfdd6fcb5871b81f8",
+    "zh:e91177ca06a15487fc570cb81ecef6359aa399459ea2aa7c4f7367ba86f6fcad",
+    "zh:e976bcb82996fc4968f8382bbcb6673efb1f586bf92074058a232028d97825b1",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.24.0"
+  constraints = "~> 2.24.0"
+  hashes = [
+    "h1:Q8+R+wE1XMfJjIixxdBo6qVni01a/P6ceSGJ+kR2z/0=",
+    "zh:0ed83ec390a7e75c4990ebce698f14234de2b6204ed9a01cd042bb7ea5f26564",
+    "zh:195150e4fdab259c70088528006f4604557a051e037ebe8de64e92840f27e40a",
+    "zh:1a334af55f7a74adf033eb871c9fe7e9e648b41ab84321114ef4ca0e7a34fba6",
+    "zh:1ef68c3832691de21a61bf1a4e268123f3e08850712eda0b893cac908a0d1bc1",
+    "zh:44a1c58e5a6646e62b0bad653319c245f3b635dd03554dea2707a38f553e4a52",
+    "zh:54b5b374c4386f7f05b3fe986f9cb57bde4beab3bdf6ee33444f2b9a81b8af64",
+    "zh:aa8c2687ab784b72f8cdad8d3c3673dea83b33561e7b3f2d287ef0d06ff2a9e5",
+    "zh:e6ecba0503052ef3ad49ad56e17b2a73d9b55e30fcb82b040189d281e25e1a3b",
+    "zh:f105393f6487d3eb1f1636ba42d10c82950ddfef852244c1bca8d526fa23a9a3",
+    "zh:f17a8f1914ec66d80ccacecd40123362cf093abee3d3aa1ff9f8f687d8736f85",
+    "zh:f394b12ef01fa0bdf666a43ad152eb3890134f35e635ea056b18771c292de46e",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  backend "gcs" {
+    bucket = "voxoff-terraform-bucket"
+    prefix = "state"
+  }
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.24.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12.0"
+    }
+  }
+
+  required_version = ">= 1.3"
+}
+
+provider "kubernetes" {
+  config_path = "~/.kube/config"  # change this if using a different kubeconfig location
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = "~/.kube/config"
+  }
+}

--- a/terraform/rabbitmq.tf
+++ b/terraform/rabbitmq.tf
@@ -1,0 +1,28 @@
+resource "helm_release" "rabbitmq" {
+  name       = "rabbitmq"
+  repository = "https://charts.bitnami.com/bitnami"
+  chart      = "rabbitmq"
+  namespace  = "default"
+
+  version = "12.1.3"
+
+  set {
+    name  = "auth.username"
+    value = "user"
+  }
+
+  set {
+    name  = "auth.password"
+    value = "password"
+  }
+
+  set {
+    name  = "auth.erlangCookie"
+    value = "thisisasecretcookie"  # Needed for clustering, can be anything
+  }
+
+  set {
+    name  = "service.type"
+    value = "ClusterIP"
+  }
+}

--- a/terraform/splitter.tf
+++ b/terraform/splitter.tf
@@ -1,0 +1,68 @@
+resource "kubernetes_deployment" "music_splitter" {
+  depends_on = [helm_release.rabbitmq]
+
+  metadata {
+    name = "music-splitter"
+    labels = {
+      app = "music-splitter"
+    }
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        app = "music-splitter"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "music-splitter"
+        }
+      }
+
+      spec {
+        container {
+          name  = "music-splitter"
+          image = "us-central1-docker.pkg.dev/bda-karaoke-app/voxoff-registry/music-splitter:latest"
+          # image = "pratikbhirud/music-splitter:latest"
+
+
+          port {
+            container_port = 8080
+          }
+
+          env {
+            name  = "RABBITMQ_HOST"
+            value = "rabbitmq.default.svc.cluster.local"
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service" "music_splitter" {
+  depends_on = [helm_release.rabbitmq]
+
+  metadata {
+    name = "music-splitter"
+  }
+
+  spec {
+    selector = {
+      app = "music-splitter"
+    }
+
+    port {
+      port        = 8080
+      target_port = 8080
+    }
+
+    type = "ClusterIP"
+  }
+}
+


### PR DESCRIPTION
BDA-36: Makes music splitter K8s ready, adds terraform deployments for splitter and rabbitmq, tested for both local and GKE deployments.